### PR TITLE
get retry count

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 src/
 __tests__/
 .circleci/
-.eslint
+.eslintrc
 tsconfig.json
 jest.config.js

--- a/README.md
+++ b/README.md
@@ -17,10 +17,28 @@ function promiseFunction() {
   })
 }
 
-ritry(() => promiseFunction(), { retry: 4 }).catch((err) => {
-  console.error(err.message)
+ritry(promiseFunction, { retry: 4 }).catch((err) => {
+  console.error(err)
 })
 ```
+
+you can gradually increase the duration.
+
+``` javascript
+import { ritry } from 'ritry'
+
+function promiseFunction({ retryCount }) {
+  const duration = 1000 + retryCount * 200
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error('fail')), duration)
+  })
+}
+
+ritry(promiseFunction, { retry: 4 }).catch((err) => {
+  console.error(err)
+})
+```
+
 ```
 declare type Callback<T> = () => Promise<T>;
 declare type Options = {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -34,7 +34,7 @@ test('should be run once by default', async () => {
   expect(mock).toBeCalledTimes(2)
 })
 
-test('should be able to get the number of retries', async () => {
+test('should be able to get the retry count', async () => {
   const numbers1: number[] = []
   const numbers2: number[] = []
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -33,3 +33,27 @@ test('should be run once by default', async () => {
   await expect(ritry(mock)).rejects.toThrow('fail')
   expect(mock).toBeCalledTimes(2)
 })
+
+test('should be able to get the number of retries', async () => {
+  const numbers1: number[] = []
+  const numbers2: number[] = []
+
+  try {
+    await ritry(({ retryCount }) => {
+      numbers1.push(retryCount)
+      return Promise.reject(new Error('fail'))
+    }, { retry: 4 })
+  } catch(_) {
+    expect(numbers1).toEqual([0, 1, 2, 3, 4])
+  }
+
+  await ritry(({ retryCount }) => {
+    return new Promise((resolve, reject) => {
+      numbers2.push(retryCount)
+      if (retryCount < 3) return reject(new Error('fail'))
+      resolve()
+    })
+  }, { retry: 4 })
+
+  expect(numbers2).toEqual([0, 1, 2, 3])
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ritry",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "main": "lib/index.js",
   "author": "highhi",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "tsc",
     "prepublish": "npm run --if-present build",
     "test": "jest",
-    "lint": "eslint --fix ./lib/**/*.ts"
+    "lint": "eslint --fix ./src/**/*.ts"
   },
   "devDependencies": {
     "@types/jest": "^24.0.12",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-type Callback<T> = () => Promise<T>
+type Callback<T> = (data: { retryCount: number }) => Promise<T>
 type Options = { retry?: number }
 
 export async function ritry<T>(callback: Callback<T>, options: Options = {}): Promise<T> {
@@ -13,7 +13,7 @@ export async function ritry<T>(callback: Callback<T>, options: Options = {}): Pr
 
   for (; count <= mergedOpts.retry; count++) {
     try {
-      result = await callback()
+      result = await callback({ retryCount: count })
       break
     } catch (err) {
       if (count >= mergedOpts.retry) {


### PR DESCRIPTION
example

```
ritry(({ retryCount }) => {
  const duration = 1000 + retryCount * 100
  return new Promise((resolve, reject) => {
    setTimeout(() => {
      if (retryCount < 2) return reject(new Error('fail'))
      resolve()
    }, duration)
  })
}, { retry: 4 })
```

you can gradually increase the duration.